### PR TITLE
Update package.js to avoid conflict with accounts-facebook

### DIFF
--- a/meteor-server/package.js
+++ b/meteor-server/package.js
@@ -22,7 +22,7 @@ Package.onUse(function (api) {
     'npm-bcrypt',
     'random',
     'ecmascript',
-    'facebook',
+    'facebook-oauth',
     'http',
     'random',
     'oauth',


### PR DESCRIPTION
I believe accounts-facebook@1.1.1 is now using facebook-oauth@1.3.0 while currently meteor-apollo-accounts is using facebook package.

This has caused the oauth service to register twice which then fails the application with the following error:
https://github.com/orionsoft/meteor-apollo-accounts/issues/46